### PR TITLE
Fix asset list images

### DIFF
--- a/webapp/inventory/templates/inventory/asset_list.html
+++ b/webapp/inventory/templates/inventory/asset_list.html
@@ -36,6 +36,7 @@
         <div class="grid">
             {% for asset in assets %}
             <div class="card">
+                <img class="asset-img" src="{% static 'equipment/' %}{{ asset.name|slugify }}.jpg" alt="{{ asset.name }}">
                 <h2>{{ asset.name }}</h2>
                 <p>{{ asset.description }}</p>
                 <p>Next Available: {{ asset.next_available|date:"j M Y" }}</p>

--- a/webapp/inventory/tests.py
+++ b/webapp/inventory/tests.py
@@ -25,3 +25,14 @@ class BookingTests(TestCase):
         self.assertFalse(self.asset.available)
         self.assertEqual(Booking.objects.count(), 1)
 
+
+class AssetListImageTests(TestCase):
+    def setUp(self):
+        self.user = User.objects.create_user("user", password="pass")
+        self.asset = Asset.objects.create(name="Camera", description="Test", category="Media")
+
+    def test_asset_list_displays_image(self):
+        self.client.login(username="user", password="pass")
+        response = self.client.get(reverse("asset_list"))
+        self.assertContains(response, "/static/equipment/camera.jpg")
+


### PR DESCRIPTION
## Summary
- show asset images on the list page
- verify images appear with a regression test

## Testing
- `python manage.py test -v 2`

------
https://chatgpt.com/codex/tasks/task_e_685dcd12bcdc8323bdc8e9556c02f6ec